### PR TITLE
Add region specific latency tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ It runs through the following tests:
 
    1. Secondly by using the system DNS resolver settings
 
+   1. Finally by querying the region-specific POPs directly (to retrieve per-region latency numbers)
+
 After the tests, it runs a couple more diagnostic commands
 
 - Outputs a prioritized list of interfaces together with their DNS settings, to help check if the device is configured correctly or if Windows may be directing queries to other services

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ It runs through the following tests:
 
 1. Test if DNS resolution is working by just issuing DNS requests using system defaults
 
-2. 1. Resolve www.sophos.com
+   1. Resolve www.sophos.com
 
-   2. Resolve www.google.com
+   1. Resolve www.google.com
 
 1. Test if the system is set up to use DNS Protection by doing a DNS lookup for dns.access.sophos.com using system defaults
 

--- a/dnsdiag.ps1
+++ b/dnsdiag.ps1
@@ -451,6 +451,27 @@ if($collectResults['systemDNS'] -eq $success) {
     Write-Result "`nSystem DNS access test failed - skipping"
 }
 
+$region_hostnames = @{
+    "PROD0" = "af45696a9d98ae9b5.awsglobalaccelerator.com"
+    "PROD1" = "af39f12a3abbc288b.awsglobalaccelerator.com"
+    "PROD2" = "a96ba037364f66208.awsglobalaccelerator.com"
+    "PROD3" = "a55ca1360a42b9e25.awsglobalaccelerator.com"
+    "PROD4" = "a66562e2168e6f91e.awsglobalaccelerator.com"
+    "PROD5" = "acec48d591c5f7b0c.awsglobalaccelerator.com"
+    "PROD6" = "a28fbfe39bd2d0a91.awsglobalaccelerator.com"
+    "PROD7" = "a5cd470aace53e730.awsglobalaccelerator.com"
+}
+
+if($collectResults['accessDNSProt'] -eq $success) {
+    $region_hostnames.getEnumerator() | Sort-Object -property:Key | ForEach {
+        Write-Result "`nCheck latency to Sophos DNS Protection ($($_.key))"
+        $ips = Resolve-DnsName -Name $_.value -Type A -Server "193.84.4.4" -DnsOnly -ErrorAction Stop | Select-Object -Property IPAddress
+        Test-DNSLatency -testname www.example.com -res $ips[0].IPAddress
+    }
+} else {
+    Write-Result "`nSophos DNS Protection access test failed - skipping"
+}
+
 Write-Result "End of test 8`n------"
 
 # Get the device's DNS settings


### PR DESCRIPTION
    - As we start to see support cases about latency, it might be useful to
      collect latency numbers for all the supported regions so that we can
      compare those results to the Global Accelerator routing decision from
      a given endpoint.
    - Iterate through the hostnames for each of the PROD POPs and perform a
      Test-DNSLatency against the first IP address returned for each of
      them.